### PR TITLE
Fix i18n plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install mkdocs-i18n==0.4.6
+          pip install mkdocs-static-i18n==1.1
           # pip install mkdocs mkdocs-material # Add other dependencies as needed
 
       - name: Build MkDocs site

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,7 @@ theme:
 plugins:
   - search
   - i18n:
+      default_language: es
       languages:
         - locale: es
           name: Español

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ mkdocs==1.6.1
 mkdocs-get-deps==0.2.0
 mkdocs-material==9.5.50
 mkdocs-material-extensions==1.3.1
-mkdocs-i18n>=0.4.6
+mkdocs-static-i18n>=1.1


### PR DESCRIPTION
## Summary
- install the correct i18n plugin
- configure default language
- update build pipeline

## Testing
- `mkdocs build` *(fails: Plugin 'i18n' option 'languages': Expected type: dict but received: list)*

------
https://chatgpt.com/codex/tasks/task_e_684923b79e6c83228278afc09951c02c